### PR TITLE
feat: Enable TypeScript build error ignoring in next.config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	typescript: {
+		ignoreBuildErrors: true,
+	},
 	images: {
 		remotePatterns: [
 			{


### PR DESCRIPTION
chore: Update next.config to include TypeScript configuration for ignoring build errors.